### PR TITLE
Prevent FLAC with zero tags from throwing a type error

### DIFF
--- a/trul.js
+++ b/trul.js
@@ -314,9 +314,14 @@ async function analyzeFileList(inDir, fileList) {
 
     // this was originally in parallel, but for >100 files it became flaky..
     const info = await probeMediaFile(absPath)
-    const tags = Object.keys(info.format.tags).map((key) => key.toUpperCase())
-    if (!["TITLE", "ARTIST", "ALBUM", "TRACK"].every((t) => tags.includes(t))) {
-      throw new Error(`[!] Required tags are not present! check ${absPath}`)
+    const formatproperties = Object.keys(info.format).map((key) => key.toUpperCase())
+    if (formatproperties.includes("TAG")) {
+      const tags = Object.keys(info.format.tags).map((key) => key.toUpperCase())
+        if (!["TITLE", "ARTIST", "ALBUM", "TRACK"].every((t) => tags.includes(t))) {
+          throw new Error(`[!] Required tags are not present! check ${absPath}`)
+        }
+    } else {
+      throw new Error(`[!] No required tags are present! check ${absPath}`)
     }
     const flacStream = info.streams.find(
       ({ codec_name }) => codec_name === "flac",


### PR DESCRIPTION
I was getting the following error on a few of my flacs that had no tags

TypeError: Cannot convert undefined or null to object
