### PR TITLE
Subdirectory filename fix

### DIFF
--- a/trul.js
+++ b/trul.js
@@ -179,7 +179,7 @@ async function* traverseFiles(baseDir) {
     const fpath = path.join(baseDir, dirent.name)
     if (dirent.isDirectory()) {
       for await (const f of traverseFiles(fpath)) {
-        yield { file: f, dir: path.join(f.dir, dirent.name) }
+        yield { file: f.file, dir: path.join(f.dir, dirent.name) }
       }
     }
     yield { file: dirent.name, dir: "." }


### PR DESCRIPTION
Was receiving an error when dealing with subdirectories

```
The "path" argument must be of type string. Received an instance of Object
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object
 ```
 
 This change resolves the error for subdirectories