### PR TITLE
Folder within a subfolder fix

### DIFF
--- a/trul.js
+++ b/trul.js
@@ -179,7 +179,7 @@ async function* traverseFiles(baseDir) {
     const fpath = path.join(baseDir, dirent.name)
     if (dirent.isDirectory()) {
       for await (const f of traverseFiles(fpath)) {
-        yield { file: f.file, dir: path.join(f.dir, dirent.name) }
+        yield { file: f.file, dir: path.join(dirent.name, f.dir) }
       }
     }
     yield { file: dirent.name, dir: "." }


### PR DESCRIPTION
Fix for issue where a folder within a subfolder would have it's path out of order and get a missing directory error. Params were just flipped

`/top/middle/bottom` instead of `/top/bottom/middle`