### PR TITLE
Verify MP3 tags before upload

### DIFF
--- a/trul.js
+++ b/trul.js
@@ -344,6 +344,54 @@ function shouldMakeFLAC(torrent, editionGroup, analyzedFiles) {
   return !encExists(RED_ENC_FLAC16, editionGroup)
 }
 
+async function verifyMp3Tags(outDir) {
+  console.log(`[-] Verifying MP3 tags in ${outDir}...`)
+  let failedFiles = []
+
+  // find mp3 files
+  for await (let { file, dir } of traverseFiles(outDir)) {
+    if (!file.endsWith(".mp3")) continue
+
+    const filePath = path.join(outDir, dir, file)
+    try {
+      // Use ffprobe to check if the file has proper tags
+      const info = await probeMediaFile(filePath)
+
+      // if any tags exist
+      if (!info.format.tags) {
+        console.log(`[!] No tags in ${filePath}`)
+        failedFiles.push(filePath)
+        continue
+      }
+
+      const tagKeys = Object.keys(info.format.tags).map((key) =>
+        key.toUpperCase()
+      )
+
+      const requiredTags = ["TITLE", "ARTIST", "ALBUM", "TRACK"]
+      const missingTags = requiredTags.filter((tag) => !tagKeys.includes(tag))
+
+      if (missingTags.length > 0) {
+        console.log(
+          `[!] Missing tags in ${filePath}: ${missingTags.join(", ")}`
+        )
+        failedFiles.push(filePath)
+      }
+    } catch (err) {
+      console.error(`[!] Error verifying tags for ${filePath}: ${err.message}`)
+      failedFiles.push(filePath)
+    }
+  }
+
+  if (failedFiles.length > 0) {
+    console.log(`[!] Found ${failedFiles.length} files with missing tags`)
+    return false
+  }
+
+  console.log(`[-] All MP3 files have proper tags`)
+  return true
+}
+
 async function main() {
   await fs.access(FLAC2MP3)
   await ensureDir(TRANSCODE_DIR)
@@ -457,6 +505,18 @@ async function main() {
 
     await doTranscode()
     await copyOtherFiles(outDir, FLAC_DIR, torrent.media)
+
+    let tagsValid = true
+    if (format === "MP3") {
+      tagsValid = await verifyMp3Tags(outDir)
+      if (!tagsValid) {
+        console.error(
+          `[!] Tag verification failed for ${outDir}. Skipping upload.`
+        )
+        continue
+      }
+    }
+
     const torrentBuffer = Buffer.from(
       await createTorrent(outDir, {
         private: true,


### PR DESCRIPTION
Ran into an issue specifically with the MP3 tagging fairly often where there was some race condition causing tagging failures within flac2mp3.

I tried setting `--processes=1` on the flac2mp3 args but actually still managed to get it to fail on the tags sometimes.

Simple "solution" here is just rechecking the tags of the newly created files before uploading. If tags are missing then it will just skip the upload and output a message so you know to try it again.